### PR TITLE
fix typo

### DIFF
--- a/src/queue/booters/consumers.booter.ts
+++ b/src/queue/booters/consumers.booter.ts
@@ -83,6 +83,6 @@ function toOptions(nameOrOptions?: string | BindingFromClassOptions) {
  */
 export const ConsumersDefaults: ArtifactOptions = {
   dirs: ['consumers'],
-  extensions: ['.consumers.js'],
+  extensions: ['.consumer.js'],
   nested: true,
 };


### PR DESCRIPTION
Like [booter controller](https://github.com/strongloop/loopback-next/blob/e25313f3a9365119d6601c7e822f4f523e1d6a3a/packages/boot/src/booters/controller.booter.ts#L51) the standard is:
1. dirs -> plural
1. extensions -> singular