### PR TITLE
allow URI string configuration options

### DIFF
--- a/src/interfaces/rabbitmq.component.config.ts
+++ b/src/interfaces/rabbitmq.component.config.ts
@@ -37,7 +37,7 @@ export interface MessageHandlerOptions {
 }
 
 export interface RabbitmqComponentConfig {
-  options: Options.Connect;
+  options?: string | Options.Connect;
   producer?: {
     idleTimeoutMillis?: number;
   };
@@ -53,7 +53,6 @@ export interface RabbitmqComponentConfig {
 }
 
 export const ConfigDefaults: RabbitmqComponentConfig = {
-  options: {},
   producer: {
     idleTimeoutMillis: 10000,
   },


### PR DESCRIPTION
Allow user to use URI string like `amqps://username:password@localhost/vhost` instead to specific each property